### PR TITLE
Agrega estilo de mensaje de error al formulario de registro

### DIFF
--- a/Templates/registrar.html
+++ b/Templates/registrar.html
@@ -52,7 +52,17 @@
         border-radius: 4px;
         font-size: 16px;
         cursor: pointer;
+        margin-top: 29px;
       }
+      .error-message {
+      background: #ffdddd;
+      color: #b30000;
+      border: 1px solid #b30000;
+      border-radius: 4px;
+      padding: 8px;
+      margin-bottom: 15px;
+      text-align: center;
+    }
     </style>
   </head>
   <body>
@@ -62,8 +72,8 @@
     <div class="Fondo">
       <form action="{{ url_for('usuario_bp.insertar_en_db') }}" method="POST">
         <div class="Formulario">
-          {% if message %}
-          <div class="{{ tipo }}">{{ message }}</div>
+          {% if error %}
+          <div class="error-message">{{ error }}</div>
           {% endif %}
           <label for="Nombre">Nombre</label>
           <input type="text" id="Nombre" name="Nombre" required />


### PR DESCRIPTION
Introduce una nueva clase CSS .error-message para mostrar mensajes de error en el formulario de registro. Actualiza la plantilla para usar la nueva variable de error y el estilo para una mejor retroalimentación del usuario.